### PR TITLE
Fix tags not showing issue

### DIFF
--- a/resources/js/Sentry/event.js
+++ b/resources/js/Sentry/event.js
@@ -16,6 +16,10 @@ export default class extends Event {
             }
         }
         this._stacktrace = this._payload.stacktrace.frames.reverse()
+        this._contexts = event.contexts || {
+            os: {},
+            runtime: {}
+        }
     }
 
     get serverName() {
@@ -47,7 +51,7 @@ export default class extends Event {
     }
 
     get os() {
-        return this.event.contexts.os
+        return this._contexts.os
     }
 
     get environment() {
@@ -55,7 +59,7 @@ export default class extends Event {
     }
 
     get runtime() {
-        return this.event.contexts.runtime
+        return this._contexts.runtime
     }
 
     get stacktrace() {


### PR DESCRIPTION
When event's contexts property was't set,
tags weren't shown. The fix is to set default
contexts value.