### PR TITLE
Fixes delimiter for var dumper logs. 

### DIFF
--- a/.rr.yaml
+++ b/.rr.yaml
@@ -32,6 +32,7 @@ tcp:
       delimiter: "\n"
     var-dumper:
       addr: 0.0.0.0:9912
+      delimiter: "\n"
     smtp:
       addr: 0.0.0.0:1025
   pool:


### PR DESCRIPTION
The problem appears only for long-running applications.